### PR TITLE
Correct addon registration syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ npm i storybook-addon-material-ui --save-dev
 Add this line to your addons.js file (create this file inside your storybook config directory if needed).
 
 ```js
-import 'storybook-addon-material-ui';
+import 'storybook-addon-material-ui/register';
 ```
 
 Now, write your stories with Material-UI Addon. By default your stories will be provided with [`Light Base Theme`](https://github.com/callemall/material-ui/blob/master/src/styles/baseThemes/lightBaseTheme.js) and [`Dark Base Theme`](https://github.com/callemall/material-ui/blob/master/src/styles/baseThemes/darkBaseTheme.js)


### PR DESCRIPTION
The documentation was missing  `/register` when importing the addon.