### PR TITLE
Fix typo in package homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "bugs": {
     "url": "https://github.com/react-theming/storybook-addon-material-ui/issues"
   },
-  "homepage": "https://github.com/react-themingstorybook-addon-material-ui",
+  "homepage": "https://github.com/react-theming/storybook-addon-material-ui",
   "dependencies": {
     "@emotion/core": "^10.0.4",
     "@emotion/styled": "^10.0.4",


### PR DESCRIPTION
When using `npm home storybook-addon-material-ui` you get directed to a 404 due to a typo. 

Only change is inserting a `/`