### PR TITLE
Allow react 17 in peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
   ],
   "storybook": {
     "displayName": "Material-UI",
-    "supportedFrameworks": ["React"],
+    "supportedFrameworks": [
+      "React"
+    ],
     "icon": "https://raw.githubusercontent.com/react-theming/storybook-addon-material-ui/master/docs/logos/material-ui.png"
   },
   "license": "MIT",
@@ -91,7 +93,7 @@
     "@storybook/addons": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
     "@storybook/react": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
     "prop-types": "^15.5.8",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "^16.0.0 || ^17.0.0",
+    "react-dom": "^16.0.0 || ^17.0.0"
   }
 }


### PR DESCRIPTION
Hello,

Doing a clean install of this package in a react 17 project with npm will raise an unmet dependency error.

Since react 17 is backwards compatible with react 16, I believe it's safe to simply raise the peer dependency version.

I've built the project with react 17 and gave it a test within the storybook just to be sure but I have not upped the version.

Let me know if any other changes are required :)