### PR TITLE
Use the permalink for Storybook icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "supportedFrameworks": [
       "React"
     ],
-    "icon": "https://raw.githubusercontent.com/react-theming/storybook-addon-material-ui/master/docs/logos/material-ui.png"
+    "icon": "https://github.com/react-theming/storybook-addon-material-ui/blob/b0ac1c444bd33212d693af182ac6fed1b069c3db/docs/logos/material-ui.png"
   },
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
The Material icon isn't appearing because the relative path can change depending on branch. I updated the icon to use the permalink URL from GitHub. 

Example of where the Material icon doesn't appear https://storybook.js.org/addons/storybook-addon-material-ui/